### PR TITLE
Include the plugins.config descriptor in jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,14 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>${project.basedir}</directory>
+                <includes>
+                    <include>plugins.config</include>
+                </includes>
+            </resource>
+        </resources>
     </build>
 
     <dependencies>


### PR DESCRIPTION
Added resources section to pom.xml so plugins.config
is included in the resulting jar file. Including this
file helps ImageJ/Fiji to recognize this plugin when
copied to the plugins folder.