### PR TITLE
pom.xml: include src/main/resources into jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,12 @@
                     <include>plugins.config</include>
                 </includes>
             </resource>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+            </resource>
         </resources>
     </build>
 


### PR DESCRIPTION
Including the plugins.config was implicitly excluding
src/main/resources, so we actually need to
include that directory, too.