### PR TITLE
LineageMapper.java: file path construction

### DIFF
--- a/src/main/java/gov/nist/isg/lineage/mapper/LineageMapper.java
+++ b/src/main/java/gov/nist/isg/lineage/mapper/LineageMapper.java
@@ -55,7 +55,7 @@ public class LineageMapper implements Runnable {
       // check for 0 or 1 based filename patterns
       String fn = Utils.getFileName(params.getFilenamePattern(), OptionsPanel
           .filenamePatternRegex, i);
-      File f = new File(params.getInputDirectory() + fn);
+      File f = new File(new File(params.getInputDirectory()), fn);
       if (f.exists()) {
         startIndex = i;
         break;
@@ -69,8 +69,9 @@ public class LineageMapper implements Runnable {
     }
 
     int imgIndex = startIndex;
-    while ((new File(params.getInputDirectory() + Utils.getFileName(params.getFilenamePattern(),
-        OptionsPanel.filenamePatternRegex, imgIndex))).exists()) {
+    while ((new File(new File(params.getInputDirectory()),
+                     Utils.getFileName(params.getFilenamePattern(),
+                                       OptionsPanel.filenamePatternRegex, imgIndex))).exists()) {
 
       String imgName = Utils.getFileName(params.getFilenamePattern(),
           OptionsPanel.filenamePatternRegex, imgIndex);


### PR DESCRIPTION
LineageMapper.java:initFramesList(): input file path creation
replaced by using File() constructor rather than String concatenation.
This handles the case calling the plugin with the input directory
parameter not ending with a path separator, e.g.
when called from an ImageJ/Fiji macro.